### PR TITLE
startup script to install msticpy

### DIFF
--- a/aznbsetup.sh
+++ b/aznbsetup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Activate environment
+source /home/nbuser/anaconda3_501/bin/activate
+
+# pip
+pip install -r /home/nbuser/library/requirements.txt


### PR DESCRIPTION
- Added Startup file aznbsetup.sh  to activate the environment and install requirements file including msticpy package.

Reference:
- https://notebooks.azure.com/help/jupyter-notebooks/server-initialization
- https://docs.microsoft.com/en-us/azure/notebooks/configure-manage-azure-notebooks-projects#one-time-initialization-script