### PR TITLE
kernelspec metadata update to python36

### DIFF
--- a/Entity Explorer - Account.ipynb
+++ b/Entity Explorer - Account.ipynb
@@ -1658,9 +1658,9 @@
   "celltoolbar": "Attachments",
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3.6.10 64-bit ('Dev': conda)",
+   "display_name": "Python 3.6",
    "language": "python",
-   "name": "python361064bitdevconda234b2b26658348549ace3025afb44b54"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Entity Explorer - IP Address.ipynb
+++ b/Entity Explorer - IP Address.ipynb
@@ -2043,9 +2043,9 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Guided Hunting - Covid-19 Themed Threats.ipynb
+++ b/Guided Hunting - Covid-19 Themed Threats.ipynb
@@ -667,9 +667,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3"
+   "name": "python36"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Changes:
- Updated metadata - kernelspec to python36 to be compatible with azure notebooks and default to python 36 kernel
- 3 notebooks which are in Notebooks gallery of Azure Sentinel
- Tested notebook renders properly after json changes