### PR TITLE
Fixed: NameError: name 'iocextract' is not defined

### DIFF
--- a/A Getting Started Guide For Azure Sentinel ML Notebooks.ipynb
+++ b/A Getting Started Guide For Azure Sentinel ML Notebooks.ipynb
@@ -715,7 +715,7 @@
    "source": [
     "import requests\n",
     "# Set up our IoCExtract oject\n",
-    "ioc_extractor = iocextract.IoCExtract()\n",
+    "ioc_extractor = IoCExtract()\n",
     "# Download our threat report\n",
     "data = requests.get(\"https://www.us-cert.gov/sites/default/files/publications/AA20-099A_WHITE.stix.xml\")\n",
     "# Extract domains listed in our report\n",


### PR DESCRIPTION
I may have a configuration issue that is causing this, but when I import and run [A Getting Started Guide For Azure Sentinel ML Notebooks.ipynb](https://github.com/Azure/Azure-Sentinel-Notebooks/blob/55602d17e47fd61db4e6c3714e1a46b295f9ff7c/A%20Getting%20Started%20Guide%20For%20Azure%20Sentinel%20ML%20Notebooks.ipynb) I get: `NameError: name 'iocextract' is not defined`

Removing `iocextract` on this line fixes the issue, and IoCs are extracted as expected.